### PR TITLE
feat(wtf): add love/unlove functionality for pins

### DIFF
--- a/backend/controllers/wtfController.js
+++ b/backend/controllers/wtfController.js
@@ -534,6 +534,84 @@ exports.likePin = async (req, res) => {
   }
 };
 
+// Love/unlove pin
+exports.lovePin = async (req, res) => {
+  try {
+    const { pinId } = req.params;
+    const studentId = req.user?.id;
+
+    if (!mongoose.Types.ObjectId.isValid(pinId)) {
+      return res.status(HTTP_STATUS_CODE.BAD_REQUEST).json({
+        success: false,
+        message: "Invalid pin ID format",
+      });
+    }
+
+    if (!studentId) {
+      return res.status(HTTP_STATUS_CODE.UNAUTHORIZED).json({
+        success: false,
+        message: "User authentication required",
+      });
+    }
+
+    logger.info(
+      {
+        clientIP: req.socket.remoteAddress,
+        method: req.method,
+        api: req.originalUrl,
+        pinId,
+        studentId,
+      },
+      `Request received to love/unlove WTF pin`
+    );
+
+    const result = await WtfService.lovePin(studentId, pinId);
+
+    if (result.success) {
+      logger.info(
+        {
+          clientIP: req.socket.remoteAddress,
+          method: req.method,
+          api: req.originalUrl,
+          pinId,
+          studentId,
+          action: result.data.action,
+        },
+        `Successfully processed pin love interaction`
+      );
+      res.status(HTTP_STATUS_CODE.OK).json(result);
+    } else {
+      errorLogger.error(
+        {
+          clientIP: req.socket.remoteAddress,
+          method: req.method,
+          api: req.originalUrl,
+          pinId,
+          studentId,
+          error: result.message,
+        },
+        `Failed to process pin love interaction`
+      );
+      res.status(HTTP_STATUS_CODE.BAD_REQUEST).json(result);
+    }
+  } catch (error) {
+    errorLogger.error(
+      {
+        clientIP: req.socket.remoteAddress,
+        method: req.method,
+        api: req.originalUrl,
+        pinId: req.params.pinId,
+        studentId: req.user?.id,
+        error: error.message,
+      },
+      `Error occurred while processing pin love interaction`
+    );
+    res
+      .status(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR)
+      .json({ success: false, message: error.message });
+  }
+};
+
 // Mark pin as seen
 exports.markPinAsSeen = async (req, res) => {
   try {

--- a/backend/data-access/wtfPin.js
+++ b/backend/data-access/wtfPin.js
@@ -34,7 +34,7 @@ exports.getActivePins = async ({
 
     // Add filters
     if (type) query.type = type;
-    if (author) query.author = mongoose.Types.ObjectId(author);
+    if (author) query.author = new mongoose.Types.ObjectId(author);
     if (isOfficial !== null) query.isOfficial = isOfficial;
 
     const pins = await WtfPin.find(query)
@@ -282,11 +282,30 @@ exports.getPinsForFifoManagement = async () => {
 // Update engagement metrics
 exports.updateEngagementMetrics = async (pinId, metrics) => {
   try {
+    console.log("🔧 updateEngagementMetrics called with:", { pinId, metrics });
+
+    // Check if pin exists first
+    const existingPin = await WtfPin.findById(pinId);
+    if (!existingPin) {
+      console.log("❌ Pin not found:", pinId);
+      return {
+        success: false,
+        data: null,
+        message: "WTF Pin not found",
+      };
+    }
+
+    console.log(
+      "🔧 Existing pin engagement metrics:",
+      existingPin.engagementMetrics
+    );
+
     const pin = await WtfPin.findByIdAndUpdate(
       pinId,
       {
         $inc: {
           "engagementMetrics.likes": metrics.likes || 0,
+          "engagementMetrics.loves": metrics.loves || 0,
           "engagementMetrics.seen": metrics.seen || 0,
           "engagementMetrics.shares": metrics.shares || 0,
         },
@@ -295,12 +314,18 @@ exports.updateEngagementMetrics = async (pinId, metrics) => {
     );
 
     if (!pin) {
+      console.log("❌ Pin not found after update:", pinId);
       return {
         success: false,
         data: null,
-        message: "WTF Pin not found",
+        message: "WTF Pin not found after update",
       };
     }
+
+    console.log(
+      "✅ Engagement metrics updated successfully:",
+      pin.engagementMetrics
+    );
 
     return {
       success: true,
@@ -308,6 +333,8 @@ exports.updateEngagementMetrics = async (pinId, metrics) => {
       message: "Engagement metrics updated successfully",
     };
   } catch (error) {
+    console.error("❌ Error in updateEngagementMetrics:", error);
+    console.error("❌ Error stack:", error.stack);
     errorLogger.error(
       { error: error.message },
       "Error in updateEngagementMetrics"
@@ -463,7 +490,7 @@ exports.getActivePinsForAdmin = async ({
 
     // Add filters
     if (type) query.type = type;
-    if (author) query.author = mongoose.Types.ObjectId(author);
+    if (author) query.author = new mongoose.Types.ObjectId(author);
     if (isOfficial !== null) query.isOfficial = isOfficial;
 
     const pins = await WtfPin.find(query)

--- a/backend/data-access/wtfStudentInteraction.js
+++ b/backend/data-access/wtfStudentInteraction.js
@@ -56,11 +56,11 @@ exports.getInteractionById = async (interactionId) => {
 exports.getStudentPinInteractions = async (studentId, pinId) => {
   try {
     const interactions = await WtfStudentInteraction.find({
-      studentId: mongoose.Types.ObjectId(studentId),
-      pinId: mongoose.Types.ObjectId(pinId)
+      studentId: new mongoose.Types.ObjectId(studentId),
+      pinId: new mongoose.Types.ObjectId(pinId),
     })
-    .populate("pinId", "title type author")
-    .lean();
+      .populate("pinId", "title type author")
+      .lean();
 
     return {
       success: true,
@@ -68,7 +68,10 @@ exports.getStudentPinInteractions = async (studentId, pinId) => {
       message: "Student pin interactions fetched successfully",
     };
   } catch (error) {
-    errorLogger.error({ error: error.message }, "Error in getStudentPinInteractions");
+    errorLogger.error(
+      { error: error.message },
+      "Error in getStudentPinInteractions"
+    );
     throw error;
   }
 };
@@ -79,16 +82,21 @@ exports.hasStudentInteracted = async (studentId, pinId, type) => {
     const exists = await WtfStudentInteraction.exists({
       studentId: new mongoose.Types.ObjectId(studentId),
       pinId: new mongoose.Types.ObjectId(pinId),
-      type: type
+      type: type,
     });
 
     return {
       success: true,
       data: { hasInteracted: !!exists },
-      message: exists ? "Student has interacted with this pin" : "Student has not interacted with this pin",
+      message: exists
+        ? "Student has interacted with this pin"
+        : "Student has not interacted with this pin",
     };
   } catch (error) {
-    errorLogger.error({ error: error.message }, "Error in hasStudentInteracted");
+    errorLogger.error(
+      { error: error.message },
+      "Error in hasStudentInteracted"
+    );
     throw error;
   }
 };
@@ -97,27 +105,27 @@ exports.hasStudentInteracted = async (studentId, pinId, type) => {
 exports.getPinInteractionCounts = async (pinId) => {
   try {
     const counts = await WtfStudentInteraction.getPinInteractionCounts(pinId);
-    
+
     // Format the results
     const formattedCounts = {
       likes: 0,
       seen: 0,
       likeTypes: {
         thumbs_up: 0,
-        green_heart: 0
-      }
+        green_heart: 0,
+      },
     };
 
-    counts.forEach(item => {
-      if (item._id === 'like') {
+    counts.forEach((item) => {
+      if (item._id === "like") {
         formattedCounts.likes = item.count;
         // Count like types
-        item.likeTypes.forEach(likeType => {
+        item.likeTypes.forEach((likeType) => {
           if (likeType) {
             formattedCounts.likeTypes[likeType]++;
           }
         });
-      } else if (item._id === 'seen') {
+      } else if (item._id === "seen") {
         formattedCounts.seen = item.count;
       }
     });
@@ -128,17 +136,23 @@ exports.getPinInteractionCounts = async (pinId) => {
       message: "Pin interaction counts fetched successfully",
     };
   } catch (error) {
-    errorLogger.error({ error: error.message }, "Error in getPinInteractionCounts");
+    errorLogger.error(
+      { error: error.message },
+      "Error in getPinInteractionCounts"
+    );
     throw error;
   }
 };
 
 // Get student's interaction history
-exports.getStudentInteractionHistory = async (studentId, { page = 1, limit = 50, type = null }) => {
+exports.getStudentInteractionHistory = async (
+  studentId,
+  { page = 1, limit = 50, type = null }
+) => {
   try {
     const skip = (page - 1) * limit;
     const query = { studentId: new mongoose.Types.ObjectId(studentId) };
-    
+
     if (type) query.type = type;
 
     const interactions = await WtfStudentInteraction.find(query)
@@ -160,23 +174,30 @@ exports.getStudentInteractionHistory = async (studentId, { page = 1, limit = 50,
           total,
           totalPages: Math.ceil(total / limit),
           hasNext: page * limit < total,
-          hasPrev: page > 1
-        }
+          hasPrev: page > 1,
+        },
       },
       message: "Student interaction history fetched successfully",
     };
   } catch (error) {
-    errorLogger.error({ error: error.message }, "Error in getStudentInteractionHistory");
+    errorLogger.error(
+      { error: error.message },
+      "Error in getStudentInteractionHistory"
+    );
     throw error;
   }
 };
 
 // Get recent interactions for analytics
-exports.getRecentInteractions = async ({ days = 7, type = null, limit = 100 }) => {
+exports.getRecentInteractions = async ({
+  days = 7,
+  type = null,
+  limit = 100,
+}) => {
   try {
     const date = new Date();
     date.setDate(date.getDate() - days);
-    
+
     const query = { createdAt: { $gte: date } };
     if (type) query.type = type;
 
@@ -193,19 +214,39 @@ exports.getRecentInteractions = async ({ days = 7, type = null, limit = 100 }) =
       message: "Recent interactions fetched successfully",
     };
   } catch (error) {
-    errorLogger.error({ error: error.message }, "Error in getRecentInteractions");
+    errorLogger.error(
+      { error: error.message },
+      "Error in getRecentInteractions"
+    );
     throw error;
   }
 };
 
 // Delete interaction (for unlike functionality)
-exports.deleteInteraction = async (studentId, pinId, type) => {
+exports.deleteInteraction = async (studentId, pinId, type, likeType = null) => {
   try {
-    const interaction = await WtfStudentInteraction.findOneAndDelete({
-      studentId: mongoose.Types.ObjectId(studentId),
-      pinId: mongoose.Types.ObjectId(pinId),
-      type: type
-    });
+    const query = {
+      studentId: new mongoose.Types.ObjectId(studentId),
+      pinId: new mongoose.Types.ObjectId(pinId),
+      type: type,
+    };
+
+    // For likes, also filter by likeType
+    if (type === "like" && likeType) {
+      query.likeType = likeType;
+    }
+
+    // For love and seen interactions, no additional fields needed
+    // likeType should not be included for these types
+
+    console.log("🗑️  deleteInteraction query:", JSON.stringify(query, null, 2));
+
+    const interaction = await WtfStudentInteraction.findOneAndDelete(query);
+
+    console.log(
+      "🗑️  deleteInteraction result:",
+      interaction ? "Found and deleted" : "Not found"
+    );
 
     if (!interaction) {
       return {
@@ -234,8 +275,8 @@ exports.updateInteraction = async (interactionId, updateData) => {
       updateData,
       { new: true, runValidators: true }
     )
-    .populate("studentId", "name role")
-    .populate("pinId", "title type author");
+      .populate("studentId", "name role")
+      .populate("pinId", "title type author");
 
     if (!interaction) {
       return {
@@ -261,7 +302,7 @@ exports.getInteractionAnalytics = async ({ days = 7, type = null }) => {
   try {
     const date = new Date();
     date.setDate(date.getDate() - days);
-    
+
     const matchStage = { createdAt: { $gte: date } };
     if (type) matchStage.type = type;
 
@@ -276,24 +317,23 @@ exports.getInteractionAnalytics = async ({ days = 7, type = null }) => {
           // For likes, also group by like type
           likeTypes: {
             $push: {
-              $cond: [
-                { $eq: ["$type", "like"] },
-                "$likeType",
-                null
-              ]
-            }
-          }
-        }
-      }
+              $cond: [{ $eq: ["$type", "like"] }, "$likeType", null],
+            },
+          },
+        },
+      },
     ]);
 
     // Calculate additional metrics
-    const totalInteractions = analytics.reduce((sum, item) => sum + item.count, 0);
+    const totalInteractions = analytics.reduce(
+      (sum, item) => sum + item.count,
+      0
+    );
     const uniqueStudentsCount = new Set(
-      analytics.flatMap(item => item.uniqueStudents)
+      analytics.flatMap((item) => item.uniqueStudents)
     ).size;
     const uniquePinsCount = new Set(
-      analytics.flatMap(item => item.uniquePins)
+      analytics.flatMap((item) => item.uniquePins)
     ).size;
 
     const result = {
@@ -302,8 +342,10 @@ exports.getInteractionAnalytics = async ({ days = 7, type = null }) => {
       uniqueStudents: uniqueStudentsCount,
       uniquePins: uniquePinsCount,
       breakdown: analytics,
-      averageInteractionsPerStudent: uniqueStudentsCount > 0 ? totalInteractions / uniqueStudentsCount : 0,
-      averageInteractionsPerPin: uniquePinsCount > 0 ? totalInteractions / uniquePinsCount : 0
+      averageInteractionsPerStudent:
+        uniqueStudentsCount > 0 ? totalInteractions / uniqueStudentsCount : 0,
+      averageInteractionsPerPin:
+        uniquePinsCount > 0 ? totalInteractions / uniquePinsCount : 0,
     };
 
     return {
@@ -312,7 +354,10 @@ exports.getInteractionAnalytics = async ({ days = 7, type = null }) => {
       message: "Interaction analytics fetched successfully",
     };
   } catch (error) {
-    errorLogger.error({ error: error.message }, "Error in getInteractionAnalytics");
+    errorLogger.error(
+      { error: error.message },
+      "Error in getInteractionAnalytics"
+    );
     throw error;
   }
 };
@@ -321,29 +366,36 @@ exports.getInteractionAnalytics = async ({ days = 7, type = null }) => {
 exports.bulkCreateInteractions = async (interactions) => {
   try {
     const result = await WtfStudentInteraction.insertMany(interactions, {
-      ordered: false // Continue inserting even if some fail
+      ordered: false, // Continue inserting even if some fail
     });
 
     return {
       success: true,
       data: {
         insertedCount: result.length,
-        interactions: result
+        interactions: result,
       },
       message: `Successfully created ${result.length} interactions`,
     };
   } catch (error) {
-    errorLogger.error({ error: error.message }, "Error in bulkCreateInteractions");
+    errorLogger.error(
+      { error: error.message },
+      "Error in bulkCreateInteractions"
+    );
     throw error;
   }
 };
 
 // Get top performing pins by interactions
-exports.getTopPerformingPins = async ({ limit = 10, type = null, days = 30 }) => {
+exports.getTopPerformingPins = async ({
+  limit = 10,
+  type = null,
+  days = 30,
+}) => {
   try {
     const date = new Date();
     date.setDate(date.getDate() - days);
-    
+
     const matchStage = { createdAt: { $gte: date } };
     if (type) matchStage.type = type;
 
@@ -354,35 +406,35 @@ exports.getTopPerformingPins = async ({ limit = 10, type = null, days = 30 }) =>
           _id: "$pinId",
           totalInteractions: { $sum: 1 },
           likes: {
-            $sum: { $cond: [{ $eq: ["$type", "like"] }, 1, 0] }
+            $sum: { $cond: [{ $eq: ["$type", "like"] }, 1, 0] },
           },
           seen: {
-            $sum: { $cond: [{ $eq: ["$type", "seen"] }, 1, 0] }
+            $sum: { $cond: [{ $eq: ["$type", "seen"] }, 1, 0] },
           },
-          uniqueStudents: { $addToSet: "$studentId" }
-        }
+          uniqueStudents: { $addToSet: "$studentId" },
+        },
       },
       {
         $addFields: {
-          uniqueStudentCount: { $size: "$uniqueStudents" }
-        }
+          uniqueStudentCount: { $size: "$uniqueStudents" },
+        },
       },
       {
-        $sort: { totalInteractions: -1 }
+        $sort: { totalInteractions: -1 },
       },
       {
-        $limit: limit
+        $limit: limit,
       },
       {
         $lookup: {
           from: "wtf_pins",
           localField: "_id",
           foreignField: "_id",
-          as: "pinDetails"
-        }
+          as: "pinDetails",
+        },
       },
       {
-        $unwind: "$pinDetails"
+        $unwind: "$pinDetails",
       },
       {
         $project: {
@@ -398,11 +450,11 @@ exports.getTopPerformingPins = async ({ limit = 10, type = null, days = 30 }) =>
             $cond: [
               { $eq: ["$seen", 0] },
               0,
-              { $multiply: [{ $divide: ["$likes", "$seen"] }, 100] }
-            ]
-          }
-        }
-      }
+              { $multiply: [{ $divide: ["$likes", "$seen"] }, 100] },
+            ],
+          },
+        },
+      },
     ]);
 
     return {
@@ -411,7 +463,10 @@ exports.getTopPerformingPins = async ({ limit = 10, type = null, days = 30 }) =>
       message: "Top performing pins fetched successfully",
     };
   } catch (error) {
-    errorLogger.error({ error: error.message }, "Error in getTopPerformingPins");
+    errorLogger.error(
+      { error: error.message },
+      "Error in getTopPerformingPins"
+    );
     throw error;
   }
-}; 
+};

--- a/backend/data-access/wtfSubmission.js
+++ b/backend/data-access/wtfSubmission.js
@@ -116,7 +116,7 @@ exports.getStudentSubmissions = async (
 ) => {
   try {
     const skip = (page - 1) * limit;
-    const query = { studentId: mongoose.Types.ObjectId(studentId) };
+    const query = { studentId: new mongoose.Types.ObjectId(studentId) };
 
     if (status) query.status = status;
     if (type) query.type = type;

--- a/backend/models/wtfPin.js
+++ b/backend/models/wtfPin.js
@@ -63,6 +63,7 @@ const wtfPinSchema = new mongoose.Schema(
     },
     engagementMetrics: {
       likes: { type: Number, default: 0 },
+      loves: { type: Number, default: 0 },
       seen: { type: Number, default: 0 },
       shares: { type: Number, default: 0 },
     },

--- a/backend/models/wtfStudentInteraction.js
+++ b/backend/models/wtfStudentInteraction.js
@@ -14,7 +14,7 @@ const wtfStudentInteractionSchema = new mongoose.Schema(
     },
     type: {
       type: String,
-      enum: ["like", "seen"],
+      enum: ["like", "seen", "love"],
       required: [true, "Interaction type is required"],
     },
     // For like interactions, we can track additional data
@@ -64,9 +64,16 @@ const wtfStudentInteractionSchema = new mongoose.Schema(
 );
 
 // Compound unique index to prevent duplicate interactions
+// For likes, we need to include likeType to allow both thumbs_up and green_heart
+wtfStudentInteractionSchema.index(
+  { studentId: 1, pinId: 1, type: 1, likeType: 1 },
+  { unique: true, partialFilterExpression: { type: "like" } }
+);
+
+// For love interactions, use the original constraint
 wtfStudentInteractionSchema.index(
   { studentId: 1, pinId: 1, type: 1 },
-  { unique: true }
+  { unique: true, partialFilterExpression: { type: { $in: ["seen", "love"] } } }
 );
 
 // Pre-save middleware to validate interaction data
@@ -81,6 +88,14 @@ wtfStudentInteractionSchema.pre("save", function (next) {
     return next(
       new Error("Valid view duration is required for seen interactions")
     );
+  }
+
+  // Love interactions don't need additional validation
+  if (this.type === "love") {
+    // Ensure likeType is not set for love interactions
+    if (this.likeType) {
+      this.likeType = undefined;
+    }
   }
 
   next();
@@ -129,16 +144,30 @@ wtfStudentInteractionSchema.statics.getStudentPinInteractions = function (
 };
 
 // Static method to check if student has interacted with a pin
+// For likes, we need to check both type and likeType
 wtfStudentInteractionSchema.statics.hasStudentInteracted = function (
   studentId,
   pinId,
-  type
+  type,
+  likeType = null
 ) {
-  return this.exists({
+  const query = {
     studentId: new mongoose.Types.ObjectId(studentId),
     pinId: new mongoose.Types.ObjectId(pinId),
     type: type,
-  });
+  };
+
+  // For likes, also check the likeType
+  if (type === "like" && likeType) {
+    query.likeType = likeType;
+  }
+
+  // For love and seen interactions, no additional fields needed
+  // likeType should not be included for these types
+
+  console.log("🔍 hasStudentInteracted query:", JSON.stringify(query, null, 2));
+
+  return this.exists(query);
 };
 
 // Static method to get student's interaction history

--- a/backend/routes/v1/wtf.js
+++ b/backend/routes/v1/wtf.js
@@ -25,6 +25,7 @@ const {
 
   // Interaction Controllers
   likePin,
+  lovePin,
   markPinAsSeen,
   getPinInteractions,
 
@@ -146,6 +147,17 @@ router.post(
   wtfInteractionValidation,
   handleValidationErrors,
   likePin
+);
+
+// Love/unlove pin (Students only)
+router.post(
+  "/pins/:pinId/love",
+  authenticate,
+  authorize(WtfPermissions.WTF_INTERACTION_CREATE, "Create"),
+  wtfSecurityHeaders,
+  wtfRateLimiters.pinInteractions,
+  handleValidationErrors,
+  lovePin
 );
 
 // Mark pin as seen (Students only)

--- a/backend/scripts/create-test-pins.js
+++ b/backend/scripts/create-test-pins.js
@@ -1,0 +1,103 @@
+const mongoose = require("mongoose");
+const WtfPin = require("../models/wtfPin");
+require("dotenv").config();
+
+async function createTestPins() {
+  try {
+    // Connect to MongoDB
+    const mongoUri =
+      process.env.MONGODB_URI || "mongodb://localhost:27017/isfplayground";
+    console.log("🔧 Connecting to:", mongoUri);
+    await mongoose.connect(mongoUri);
+    console.log("✅ Connected to MongoDB");
+
+    // Check if pins already exist
+    const existingPins = await WtfPin.countDocuments();
+    if (existingPins > 0) {
+      console.log(`🔧 Found ${existingPins} existing pins, skipping creation`);
+      return;
+    }
+
+    // Create a test user ID (you'll need to replace this with a real user ID from your users collection)
+    const testUserId = new mongoose.Types.ObjectId();
+
+    // Create test pins
+    const testPins = [
+      {
+        title: "vvv",
+        content: "Audio content",
+        type: "audio",
+        mediaUrl: "test-audio.mp3",
+        author: testUserId,
+        status: "active",
+        isOfficial: false,
+        language: "english",
+        tags: ["audio", "podcast"],
+        engagementMetrics: {
+          likes: 0,
+          loves: 0,
+          seen: 0,
+          shares: 0,
+        },
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+      },
+      {
+        title: "Video",
+        content: "Video content",
+        type: "video",
+        mediaUrl: "test-video.mp4",
+        author: testUserId,
+        status: "active",
+        isOfficial: false,
+        language: "english",
+        tags: ["video", "performance"],
+        engagementMetrics: {
+          likes: 0,
+          loves: 0,
+          seen: 0,
+          shares: 0,
+        },
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+      },
+      {
+        title: "Video",
+        content: "Another video content",
+        type: "video",
+        mediaUrl: "test-video-2.mp4",
+        author: testUserId,
+        status: "active",
+        isOfficial: false,
+        language: "english",
+        tags: ["video", "tutorial"],
+        engagementMetrics: {
+          likes: 0,
+          loves: 0,
+          seen: 0,
+          shares: 0,
+        },
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+      },
+    ];
+
+    console.log("🔧 Creating test pins...");
+    const createdPins = await WtfPin.insertMany(testPins);
+
+    console.log(`✅ Created ${createdPins.length} test pins:`);
+    createdPins.forEach((pin) => {
+      console.log(`  - ${pin.title} (${pin.type}) - ID: ${pin._id}`);
+    });
+
+    // Verify the pins were created
+    const totalPins = await WtfPin.countDocuments();
+    console.log(`🔧 Total pins in database: ${totalPins}`);
+  } catch (error) {
+    console.error("❌ Error creating test pins:", error);
+    console.error("❌ Error stack:", error.stack);
+  } finally {
+    await mongoose.disconnect();
+    console.log("🔌 Disconnected from MongoDB");
+  }
+}
+
+// Run the script
+createTestPins();

--- a/backend/scripts/init-engagement-metrics.js
+++ b/backend/scripts/init-engagement-metrics.js
@@ -1,0 +1,57 @@
+const mongoose = require("mongoose");
+const WtfPin = require("../models/wtfPin");
+require("dotenv").config();
+
+async function initEngagementMetrics() {
+  try {
+    // Connect to MongoDB
+    await mongoose.connect(
+      process.env.MONGODB_URI || "mongodb://localhost:27017/isfplayground"
+    );
+    console.log("Connected to MongoDB");
+
+    // Find all pins that don't have engagementMetrics or have incomplete engagementMetrics
+    const pins = await WtfPin.find({
+      $or: [
+        { engagementMetrics: { $exists: false } },
+        { "engagementMetrics.likes": { $exists: false } },
+        { "engagementMetrics.loves": { $exists: false } },
+        { "engagementMetrics.seen": { $exists: false } },
+        { "engagementMetrics.shares": { $exists: false } },
+      ],
+    });
+
+    console.log(
+      `Found ${pins.length} pins that need engagement metrics initialization`
+    );
+
+    // Initialize engagement metrics for each pin
+    for (const pin of pins) {
+      const updateData = {
+        "engagementMetrics.likes": pin.engagementMetrics?.likes || 0,
+        "engagementMetrics.loves": pin.engagementMetrics?.loves || 0,
+        "engagementMetrics.seen": pin.engagementMetrics?.seen || 0,
+        "engagementMetrics.shares": pin.engagementMetrics?.shares || 0,
+      };
+
+      await WtfPin.findByIdAndUpdate(pin._id, {
+        $set: updateData,
+      });
+
+      console.log(
+        `Updated pin ${pin._id} with engagement metrics:`,
+        updateData
+      );
+    }
+
+    console.log("Engagement metrics initialization completed successfully");
+  } catch (error) {
+    console.error("Error initializing engagement metrics:", error);
+  } finally {
+    await mongoose.disconnect();
+    console.log("Disconnected from MongoDB");
+  }
+}
+
+// Run the script
+initEngagementMetrics();

--- a/backend/scripts/test-engagement.js
+++ b/backend/scripts/test-engagement.js
@@ -1,0 +1,76 @@
+const mongoose = require("mongoose");
+const WtfPin = require("../models/wtfPin");
+const { updateEngagementMetrics } = require("../data-access/wtfPin");
+require("dotenv").config();
+
+async function testEngagement() {
+  try {
+    // Connect to MongoDB
+    const mongoUri =
+      process.env.MONGODB_URI || "mongodb://localhost:27017/isfplayground";
+    console.log("🔧 Connecting to:", mongoUri);
+    await mongoose.connect(mongoUri);
+    console.log("✅ Connected to MongoDB");
+
+    // Check what database we're connected to
+    const dbName = mongoose.connection.db.databaseName;
+    console.log("🔧 Connected to database:", dbName);
+
+    // List all collections
+    const collections = await mongoose.connection.db
+      .listCollections()
+      .toArray();
+    console.log(
+      "🔧 Available collections:",
+      collections.map((c) => c.name)
+    );
+
+    // Check if there are any documents in the wtf_pins collection
+    const pinCount = await WtfPin.countDocuments();
+    console.log("🔧 Total pins in wtf_pins collection:", pinCount);
+
+    // Find a pin to test with
+    const pin = await WtfPin.findOne();
+    if (!pin) {
+      console.log("❌ No pins found at all");
+      return;
+    }
+
+    console.log("🔧 Testing with pin:", {
+      id: pin._id,
+      title: pin.title,
+      status: pin.status,
+      currentMetrics: pin.engagementMetrics,
+    });
+
+    // Test the updateEngagementMetrics function
+    console.log("🔧 Testing updateEngagementMetrics...");
+    const result = await updateEngagementMetrics(pin._id, { likes: 1 });
+
+    if (result.success) {
+      console.log(
+        "✅ updateEngagementMetrics succeeded:",
+        result.data.engagementMetrics
+      );
+    } else {
+      console.log("❌ updateEngagementMetrics failed:", result.message);
+    }
+
+    // Verify the update in the database
+    const updatedPin = await WtfPin.findById(pin._id);
+    console.log("🔧 Pin after update:", {
+      id: updatedPin._id,
+      title: updatedPin.title,
+      metrics: updatedPin.engagementMetrics,
+    });
+  } catch (error) {
+    console.error("❌ Error in test:", error);
+    console.error("❌ Error stack:", error.stack);
+  } finally {
+    await mongoose.disconnect();
+    console.log("🔌 Disconnected from MongoDB");
+  }
+}
+
+// Run the test
+testEngagement();

--- a/backend/services/wtf.js
+++ b/backend/services/wtf.js
@@ -296,9 +296,10 @@ class WtfService {
       if (result.success) {
         // Update engagement metrics for the new pin
         await updateEngagementMetrics(result.data._id, {
-          "engagementMetrics.likes": 0,
-          "engagementMetrics.seen": 0,
-          "engagementMetrics.shares": 0,
+          likes: 0,
+          loves: 0,
+          seen: 0,
+          shares: 0,
         });
 
         // Award coins for pin creation
@@ -663,16 +664,43 @@ class WtfService {
         };
       }
 
-      // Check if student already liked this pin
-      const hasLiked = await hasStudentInteracted(studentId, pinId, "like");
+      // Check if student already liked this pin with this specific likeType
+      const hasLiked = await hasStudentInteracted(
+        studentId,
+        pinId,
+        "like",
+        likeType
+      );
+
+      console.log("🔍 Interaction check:", {
+        studentId,
+        pinId,
+        likeType,
+        hasLiked: hasLiked.data.hasInteracted,
+        hasLikedData: hasLiked.data,
+      });
+
       if (hasLiked.data.hasInteracted) {
-        // Unlike: delete the interaction
-        const deleteResult = await deleteInteraction(studentId, pinId, "like");
+        // Unlike: delete the specific interaction
+        console.log("🗑️  Attempting to delete interaction:", {
+          studentId,
+          pinId,
+          type: "like",
+          likeType,
+        });
+
+        const deleteResult = await deleteInteraction(
+          studentId,
+          pinId,
+          "like",
+          likeType
+        );
+
+        console.log("🗑️  Delete result:", deleteResult);
+
         if (deleteResult.success) {
           // Update engagement metrics
-          await updateEngagementMetrics(pinId, {
-            "engagementMetrics.likes": -1,
-          });
+          await updateEngagementMetrics(pinId, { likes: -1 });
           return {
             success: true,
             data: { action: "unliked", likeType: null },
@@ -693,7 +721,8 @@ class WtfService {
       const result = await createInteraction(interactionData);
       if (result.success) {
         // Update engagement metrics
-        await updateEngagementMetrics(pinId, { "engagementMetrics.likes": 1 });
+        console.log("🔧 likePin: Updating engagement metrics for pin:", pinId);
+        await updateEngagementMetrics(pinId, { likes: 1 });
 
         // Award coins for interaction (with daily limit)
         try {
@@ -743,6 +772,125 @@ class WtfService {
       return result;
     } catch (error) {
       errorLogger.error({ error: error.message }, "Error in likePin service");
+      throw error;
+    }
+  }
+
+  static async lovePin(studentId, pinId) {
+    try {
+      if (!studentId || !pinId) {
+        return {
+          success: false,
+          data: null,
+          message: "Student ID and Pin ID are required",
+        };
+      }
+
+      // Validate ObjectId format
+      if (!mongoose.Types.ObjectId.isValid(studentId)) {
+        return {
+          success: false,
+          data: null,
+          message: "Invalid student ID format",
+        };
+      }
+
+      if (!mongoose.Types.ObjectId.isValid(pinId)) {
+        return {
+          success: false,
+          data: null,
+          message: "Invalid pin ID format",
+        };
+      }
+
+      // Check if pin exists and is active
+      const pinResult = await getWtfPinById(pinId);
+      if (!pinResult.success) {
+        return {
+          success: false,
+          data: null,
+          message: "Pin not found or not active",
+        };
+      }
+
+      // Check if student already loved this pin
+      const hasLoved = await hasStudentInteracted(studentId, pinId, "love");
+      if (hasLoved.data.hasInteracted) {
+        // Unlove: delete the interaction
+        const deleteResult = await deleteInteraction(studentId, pinId, "love");
+        if (deleteResult.success) {
+          // Update engagement metrics
+          await updateEngagementMetrics(pinId, { loves: -1 });
+          return {
+            success: true,
+            data: { action: "unloved" },
+            message: "Pin unloved successfully",
+          };
+        }
+        return deleteResult;
+      }
+
+      // Love: create new interaction
+      const interactionData = {
+        studentId: new mongoose.Types.ObjectId(studentId),
+        pinId: new mongoose.Types.ObjectId(pinId),
+        type: "love",
+      };
+
+      const result = await createInteraction(interactionData);
+      if (result.success) {
+        // Update engagement metrics
+        console.log("🔧 lovePin: Updating engagement metrics for pin:", pinId);
+        await updateEngagementMetrics(pinId, { loves: 1 });
+
+        // Award coins for interaction (with daily limit)
+        try {
+          const coinResult = await CoinService.awardInteractionCoins(
+            studentId,
+            result.data._id,
+            {
+              pinId: pinId,
+              likeType: "love",
+              userAgent: metadata?.userAgent,
+              ipAddress: metadata?.ipAddress,
+            }
+          );
+
+          // Add coin information to response if coins were awarded
+          if (coinResult.success) {
+            result.data.coinAward = coinResult.data;
+          }
+        } catch (coinError) {
+          errorLogger.error(
+            { studentId, pinId, error: coinError.message },
+            "Error awarding coins for interaction"
+          );
+          // Don't fail the interaction if coin awarding fails
+        }
+
+        // Trigger real-time event
+        try {
+          wtfWebSocketService.handlePinLiked(pinId, studentId, {
+            likeType: "love",
+            interactionId: result.data._id,
+          });
+        } catch (wsError) {
+          errorLogger.error(
+            { pinId, studentId, error: wsError.message },
+            "Error triggering WebSocket pin loved event"
+          );
+        }
+
+        return {
+          success: true,
+          data: { action: "loved", ...result.data },
+          message: "Pin loved successfully",
+        };
+      }
+
+      return result;
+    } catch (error) {
+      errorLogger.error({ error: error.message }, "Error in lovePin service");
       throw error;
     }
   }
@@ -801,7 +949,7 @@ class WtfService {
       const result = await createInteraction(interactionData);
       if (result.success) {
         // Update engagement metrics
-        await updateEngagementMetrics(pinId, { "engagementMetrics.seen": 1 });
+        await updateEngagementMetrics(pinId, { seen: 1 });
         // Trigger real-time event
         try {
           wtfWebSocketService.handlePinSeen(pinId, studentId, {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -905,12 +905,24 @@ export const changeWtfPinStatus = async (pinId, status) => {
 };
 
 // Interaction APIs
-export const likeWtfPin = async (pinId) => {
+export const likeWtfPin = async (pinId, likeType = "thumbs_up") => {
   try {
-    const response = await api.post(`/api/v1/wtf/pins/${pinId}/like`);
+    const response = await api.post(`/api/v1/wtf/pins/${pinId}/like`, {
+      likeType,
+    });
     return response.data;
   } catch (error) {
     console.error("Error liking WTF pin:", error);
+    throw error;
+  }
+};
+
+export const loveWtfPin = async (pinId) => {
+  try {
+    const response = await api.post(`/api/v1/wtf/pins/${pinId}/love`);
+    return response.data;
+  } catch (error) {
+    console.error("Error loving WTF pin:", error);
     throw error;
   }
 };

--- a/frontend/src/components/wtf/WTFManagement.js
+++ b/frontend/src/components/wtf/WTFManagement.js
@@ -45,6 +45,11 @@ import {
   getWtfAnalytics,
   getWtfDashboardCounts,
   getCoachSuggestions,
+  getWtfPinInteractions,
+  getStudentSubmissions,
+  getWtfSubmissionStats,
+  getCoachSuggestionsCount,
+  getPendingSubmissionsCount,
 } from "../../api";
 
 const WTFManagementContent = ({ onToggleView }) => {
@@ -105,11 +110,14 @@ const WTFManagementContent = ({ onToggleView }) => {
         limit: 20,
         type: filterType === "all" ? null : filterType,
       });
-      const fetchedPins =
-        pinsResponse.success && pinsResponse.data && pinsResponse.data.pins
-          ? pinsResponse.data.pins
-          : [];
-      setActivePins(fetchedPins);
+      if (pinsResponse.success && pinsResponse.data && pinsResponse.data.pins) {
+        const pins = pinsResponse.data.pins;
+        setActivePins(pins);
+        setTotalItems(pinsResponse.data.pagination?.total || pins.length);
+      } else {
+        setActivePins([]);
+        setTotalItems(0);
+      }
 
       // Fetch submissions for review
       let fetchedSubmissions = [];
@@ -121,7 +129,9 @@ const WTFManagementContent = ({ onToggleView }) => {
         });
         if (submissionsResponse.success) {
           fetchedSubmissions =
-            (submissionsResponse.data && submissionsResponse.data.submissions) || [];
+            (submissionsResponse.data &&
+              submissionsResponse.data.submissions) ||
+            [];
           setStudentSubmissions(fetchedSubmissions);
         } else {
           setStudentSubmissions([]);
@@ -200,7 +210,7 @@ const WTFManagementContent = ({ onToggleView }) => {
         // Fallback to local calculations using the fetched data
         setDashboardMetrics(
           calculateDashboardMetrics(
-            fetchedPins,
+            activePins,
             fetchedSuggestions,
             fetchedSubmissions
           )
@@ -876,13 +886,13 @@ const WTFManagementContent = ({ onToggleView }) => {
                               <div className="flex items-center gap-1">
                                 <Heart className="w-4 h-4 text-red-500" />
                                 <span className="text-gray-700">
-                                  {pin.engagementMetrics?.shares || 0}
+                                  {pin.engagementMetrics?.loves ?? 0}
                                 </span>
                               </div>
                               <div className="flex items-center gap-1">
                                 <ThumbsUp className="w-4 h-4 text-blue-500" />
                                 <span className="text-gray-700">
-                                  {pin.engagementMetrics?.likes || 0}
+                                  {pin.engagementMetrics?.likes ?? 0}
                                 </span>
                               </div>
                             </div>
@@ -1417,7 +1427,8 @@ const WTFManagementContent = ({ onToggleView }) => {
                       {(() => {
                         const voiceCount = Array.isArray(studentSubmissions)
                           ? studentSubmissions.filter(
-                              (s) => s.status === "pending" && s.type === "voice"
+                              (s) =>
+                                s.status === "pending" && s.type === "voice"
                             ).length
                           : 0;
                         return voiceCount > 0 ? (
@@ -1439,7 +1450,8 @@ const WTFManagementContent = ({ onToggleView }) => {
                       {(() => {
                         const articleCount = Array.isArray(studentSubmissions)
                           ? studentSubmissions.filter(
-                              (s) => s.status === "pending" && s.type === "article"
+                              (s) =>
+                                s.status === "pending" && s.type === "article"
                             ).length
                           : 0;
                         return articleCount > 0 ? (
@@ -1475,8 +1487,9 @@ const WTFManagementContent = ({ onToggleView }) => {
                         </thead>
                         <tbody>
                           {(Array.isArray(studentSubmissions)
-                           ? studentSubmissions.filter(
-                               (s) => s.status === "pending" && s.type === "voice"
+                            ? studentSubmissions.filter(
+                                (s) =>
+                                  s.status === "pending" && s.type === "voice"
                               )
                             : []
                           ).map((submission) => (
@@ -1563,7 +1576,7 @@ const WTFManagementContent = ({ onToggleView }) => {
                         </thead>
                         <tbody>
                           {(Array.isArray(studentSubmissions)
-                           ? studentSubmissions.filter(
+                            ? studentSubmissions.filter(
                                 (s) =>
                                   s.status === "pending" && s.type === "article"
                               )

--- a/frontend/src/components/wtf/WallOfFame.js
+++ b/frontend/src/components/wtf/WallOfFame.js
@@ -32,7 +32,9 @@ import TextReader from "./modals/TextReader";
 import {
   getActiveWtfPins,
   likeWtfPin,
+  loveWtfPin,
   markWtfPinAsSeen,
+  getWtfPinInteractions,
   createWtfPin,
   createCoachSuggestion,
   getWtfSubmissionStats,
@@ -114,10 +116,23 @@ const WallOfFameContent = ({ onToggleView }) => {
   useEffect(() => {
     const fetchPins = async () => {
       try {
+        console.log("🔧 Frontend: Fetching pins...");
         const response = await getActiveWtfPins();
+        console.log("🔧 Frontend: getActiveWtfPins response:", response);
+
         if (response.success && response.data && response.data.pins) {
-          setContent(response.data.pins);
+          const pins = response.data.pins;
+          console.log(
+            "🔧 Frontend: Setting content with pins:",
+            pins.map((p) => ({
+              id: p._id || p.id,
+              title: p.title,
+              engagementMetrics: p.engagementMetrics,
+            }))
+          );
+          setContent(pins);
         } else {
+          console.log("🔧 Frontend: No pins found or error response");
           setContent([]);
         }
       } catch (error) {
@@ -160,8 +175,18 @@ const WallOfFameContent = ({ onToggleView }) => {
     return () => clearInterval(interval);
   }, [isAdmin]);
 
-  const handlePinClick = (item) => {
-    setSelectedContent(item);
+  const handlePinClick = async (item) => {
+    // Find the most up-to-date version of this pin from the current content state
+    const currentPin = content.find(
+      (pin) => (pin._id || pin.id) === (item._id || item.id)
+    );
+
+    if (currentPin) {
+      setSelectedContent(currentPin);
+    } else {
+      setSelectedContent(item);
+    }
+
     // Map backend types to frontend modal types
     const modalTypeMap = {
       image: "photo",
@@ -421,12 +446,35 @@ const WallOfFameContent = ({ onToggleView }) => {
 
   const handleLikePin = async (pinId) => {
     try {
-      await likeWtfPin(pinId);
-      setContent((prev) =>
-        prev.map((pin) =>
-          pin.id === pinId ? { ...pin, likes: pin.likes + 1 } : pin
-        )
-      );
+      console.log("🔧 Frontend: handleLikePin called for pin:", pinId);
+      const resp = await likeWtfPin(pinId, "thumbs_up");
+      console.log("🔧 Frontend: likeWtfPin response:", resp);
+
+      setContent((prev) => {
+        console.log("🔧 Frontend: Updating content state, prev:", prev);
+        return prev.map((pin) => {
+          const currentId = pin.id || pin._id;
+          if (currentId !== pinId) return pin;
+          const currentLikes = pin.engagementMetrics?.likes ?? 0;
+          const delta = resp?.data?.action === "unliked" ? -1 : 1;
+          const newLikes = Math.max(0, currentLikes + delta);
+          console.log(
+            "🔧 Frontend: Pin",
+            currentId,
+            "likes:",
+            currentLikes,
+            "->",
+            newLikes
+          );
+          return {
+            ...pin,
+            engagementMetrics: {
+              ...pin.engagementMetrics,
+              likes: newLikes,
+            },
+          };
+        });
+      });
     } catch (error) {
       console.error("Error liking pin:", error);
     }
@@ -434,12 +482,38 @@ const WallOfFameContent = ({ onToggleView }) => {
 
   const handleHeartPin = async (pinId) => {
     try {
-      await likeWtfPin(pinId); // Assuming likeWtfPin handles hearts too
-      setContent((prev) =>
-        prev.map((pin) =>
-          pin.id === pinId ? { ...pin, hearts: pin.hearts + 1 } : pin
-        )
-      );
+      console.log("🔧 Frontend: handleHeartPin called for pin:", pinId);
+      const resp = await loveWtfPin(pinId);
+      console.log("🔧 Frontend: loveWtfPin response:", resp);
+
+      setContent((prev) => {
+        console.log(
+          "🔧 Frontend: Updating content state for heart, prev:",
+          prev
+        );
+        return prev.map((pin) => {
+          const currentId = pin.id || pin._id;
+          if (currentId !== pinId) return pin;
+          const currentLoves = pin.engagementMetrics?.loves ?? 0;
+          const delta = resp?.data?.action === "unloved" ? -1 : 1;
+          const newLoves = Math.max(0, currentLoves + delta);
+          console.log(
+            "🔧 Frontend: Pin",
+            currentId,
+            "loves:",
+            currentLoves,
+            "->",
+            newLoves
+          );
+          return {
+            ...pin,
+            engagementMetrics: {
+              ...pin.engagementMetrics,
+              loves: newLoves,
+            },
+          };
+        });
+      });
     } catch (error) {
       console.error("Error hearting pin:", error);
     }
@@ -449,7 +523,21 @@ const WallOfFameContent = ({ onToggleView }) => {
     try {
       await markWtfPinAsSeen(pinId);
       setContent((prev) =>
-        prev.map((pin) => (pin.id === pinId ? { ...pin, isSeen: true } : pin))
+        prev.map((pin) => {
+          const currentId = pin.id || pin._id;
+          if (currentId !== pinId) return pin;
+          if (pin.engagementMetrics) {
+            const currentSeen = pin.engagementMetrics.seen ?? 0;
+            return {
+              ...pin,
+              engagementMetrics: {
+                ...pin.engagementMetrics,
+                seen: currentSeen + 1,
+              },
+            };
+          }
+          return { ...pin, isSeen: true };
+        })
       );
     } catch (error) {
       console.error("Error marking pin as seen:", error);
@@ -523,7 +611,7 @@ const WallOfFameContent = ({ onToggleView }) => {
 
   const renderCard = (item) => (
     <div
-      key={item.id}
+      key={item._id || item.id}
       className="bg-yellow-50 p-4 cursor-pointer hover:scale-105 transition-all duration-300 hover:shadow-xl relative"
       onClick={(e) => {
         e.preventDefault();
@@ -553,18 +641,50 @@ const WallOfFameContent = ({ onToggleView }) => {
       </div>
 
       <div className="flex items-center justify-center gap-3 mb-2 text-xs">
-        <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className="flex items-center gap-1 hover:opacity-80"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            handleMarkAsSeen(item.id || item._id);
+          }}
+        >
           <Eye className="w-3 h-3 text-gray-600" />
-          <span className="text-gray-700 font-medium">{item.views}</span>
-        </div>
-        <div className="flex items-center gap-1">
+          <span className="text-gray-700 font-medium">
+            {item.engagementMetrics?.seen ?? item.views ?? 0}
+          </span>
+        </button>
+        <button
+          type="button"
+          className="flex items-center gap-1 hover:opacity-80"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            handleHeartPin(item.id || item._id);
+          }}
+          aria-label="Love"
+        >
           <Heart className="w-3 h-3 text-red-500" />
-          <span className="text-gray-700 font-medium">{item.hearts}</span>
-        </div>
-        <div className="flex items-center gap-1">
+          <span className="text-gray-700 font-medium">
+            {item.engagementMetrics?.loves ?? 0}
+          </span>
+        </button>
+        <button
+          type="button"
+          className="flex items-center gap-1 hover:opacity-80"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            handleLikePin(item.id || item._id);
+          }}
+          aria-label="Like"
+        >
           <ThumbsUp className="w-3 h-3 text-pink-500" />
-          <span className="text-gray-700 font-medium">{item.likes}</span>
-        </div>
+          <span className="text-gray-700 font-medium">
+            {item.engagementMetrics?.likes ?? 0}
+          </span>
+        </button>
       </div>
 
       {item.type === "photo" && (
@@ -1044,7 +1164,7 @@ const WallOfFameContent = ({ onToggleView }) => {
           title={selectedContent.title}
           author={selectedContent.author}
           likes={selectedContent.engagementMetrics?.likes || 0}
-          hearts={selectedContent.engagementMetrics?.shares || 0}
+          hearts={selectedContent.engagementMetrics?.loves || 0}
           views={selectedContent.engagementMetrics?.seen || 0}
         />
       )}
@@ -1057,7 +1177,7 @@ const WallOfFameContent = ({ onToggleView }) => {
           title={selectedContent.title}
           author={selectedContent.author}
           likes={selectedContent.engagementMetrics?.likes || 0}
-          hearts={selectedContent.engagementMetrics?.shares || 0}
+          hearts={selectedContent.engagementMetrics?.loves || 0}
           views={selectedContent.engagementMetrics?.seen || 0}
         />
       )}
@@ -1070,7 +1190,7 @@ const WallOfFameContent = ({ onToggleView }) => {
           title={selectedContent.title}
           author={selectedContent.author}
           likes={selectedContent.engagementMetrics?.likes || 0}
-          hearts={selectedContent.engagementMetrics?.shares || 0}
+          hearts={selectedContent.engagementMetrics?.loves || 0}
           views={selectedContent.engagementMetrics?.seen || 0}
         />
       )}
@@ -1083,7 +1203,7 @@ const WallOfFameContent = ({ onToggleView }) => {
           content={selectedContent.content}
           author={selectedContent.author}
           likes={selectedContent.engagementMetrics?.likes || 0}
-          hearts={selectedContent.engagementMetrics?.shares || 0}
+          hearts={selectedContent.engagementMetrics?.loves || 0}
           views={selectedContent.engagementMetrics?.seen || 0}
         />
       )}


### PR DESCRIPTION
- Implemented `lovePin` endpoint to allow students to express love for pins, including validation and interaction handling.
- Updated engagement metrics to track loves alongside likes.
- Enhanced interaction checks to support both love and like types.
- Modified frontend components to integrate love functionality, including API calls and state management for loves.
- Improved logging for love/unlove interactions to facilitate better tracking and debugging.